### PR TITLE
feat: 커버이미지 default값 지정 및 db 이모티콘 설정

### DIFF
--- a/backend/gdiary/models.py
+++ b/backend/gdiary/models.py
@@ -1,3 +1,4 @@
+from django.db import models
 from django.contrib.auth.base_user import BaseUserManager, AbstractBaseUser
 from django.contrib.auth.models import PermissionsMixin
 
@@ -45,7 +46,7 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel):
     email = models.EmailField(default='', max_length=100, null=False, unique=True)
     nickname = models.CharField(max_length=10, null=False, unique=True)
 
-    cover_image_url=models.CharField(max_length=500, null= False)
+    cover_image_url=models.CharField(max_length=500, null= False, default="https://gdiary-s3-bucket.s3.ap-northeast-2.amazonaws.com/mainLogo.png")
 
     is_active = models.BooleanField(default=True)
     is_admin = models.BooleanField(default=False)
@@ -75,6 +76,7 @@ class Diary(BaseModel):
     user_id = models.ForeignKey(User, on_delete=models.CASCADE, null=False) #fk
     title = models.CharField(max_length=50, null=False)
     weather = models.IntegerField(null=False)
+    emoji = models.CharField(max_length=500, null=False)
     drawing_url = models.CharField(max_length=500, null=True)
     contents = models.CharField(max_length=50, null=False)
     diary_date = models.DateField(null=False)


### PR DESCRIPTION
## 기능 설명

- 커버사진 default값 지정 (s3 bucket에 이미지 저장 후 url 가져와서 지정)
- db에 이모티콘 설정 
`‘charset’ : utf8mb4’` 추가 
![image](https://user-images.githubusercontent.com/101381901/215309579-5a4e5c95-e94c-4b6f-965f-ab6a1f717308.png)



<br>
참고자료
https://velog.io/@devmin/mysql-database-utf8mb4-django

## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 추가/수정사항을 설명하였는가?